### PR TITLE
Add: 振り返り機能の追加

### DIFF
--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the answers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -24,9 +24,22 @@ class AnswersController < ApplicationController
 
   def create
 
+  today = Time.zone.today.strftime("%Y年 %m月 %d日")
+
+  days = current_user.answers.pluck(:created_at)
+
+  days.each do |d|
+    if d.strftime("%Y年 %m月 %d日") == today
+      flash[:notice] = "振り返りは一日一回までです！"
+      @rules = current_user.rules ||= ""
+      render action: :new and return
+    end
+  end
+
     @rules = current_user.rules
     @child_answers = answer_params
     @answer = Answer.new(user_id: current_user.id)
+
     is_error = false
 
     if @child_answers['value'].to_hash.size == 15

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -9,7 +9,6 @@ class AnswersController < ApplicationController
     @answer.user_id = current_user.id
 
     @rules = current_user.rules
-    @rule = Rule.find(current_user.id)
   end
 
   def create

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -29,6 +29,8 @@ class AnswersController < ApplicationController
           end
         end
 
+        Answer.score_create(@answer)
+
         if is_error
           flash[:notice] = "振り返り実行に失敗しました"
           @rules = current_user.rules ||= ""

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -30,7 +30,7 @@ class AnswersController < ApplicationController
 
   days.each do |d|
     if d.strftime("%Y年 %m月 %d日") == today
-      flash[:notice] = "振り返りは一日一回までです！"
+      flash.now[:notice] = "振り返りは一日一回までです！"
       @rules = current_user.rules ||= ""
       render action: :new and return
     end
@@ -53,7 +53,7 @@ class AnswersController < ApplicationController
         end
 
          if is_error
-          flash[:notice] = "振り返り実行に失敗しました"
+          flash.now[:notice] = "振り返り実行に失敗しました"
           @rules = current_user.rules ||= ""
           render action: :new and return
          else
@@ -69,7 +69,7 @@ class AnswersController < ApplicationController
     end
 
     if is_error
-      flash[:notice] = "振り返り実行に失敗しました"
+      flash.now[:notice] = "振り返り実行に失敗しました"
       @rules = current_user.rules ||= ""
       render action: :new and return
     end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -2,6 +2,11 @@ class AnswersController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @answers = current_user.answers
+  end
+
+  def board
+    @answers = Answer.all.includes(:user)
   end
 
   def new
@@ -12,7 +17,7 @@ class AnswersController < ApplicationController
   end
 
   def show
-    @answer = Answer.find_by(id: params[:id], user_id: current_user.id)
+    @answer = Answer.find_by(id: params[:id])
     @child_answers = @answer.child_answers
     @success_result = Answer.success_result(@answer)
   end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -37,7 +37,7 @@ class AnswersController < ApplicationController
         end
 
         flash[:notice] = "振り返りを実施しました"
-        redirect_to answers_index_path
+        redirect_to answers_path
       end
 
     else

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,62 @@
+class AnswersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+
+  def new
+    @answer = Answer.new()
+    @answer.user_id = current_user.id
+
+    @rules = current_user.rules
+    @rule = Rule.find(current_user.id)
+  end
+
+  def create
+
+    @rules = current_user.rules
+    @child_answers = answer_params
+    @answer = Answer.new(user_id: current_user.id)
+    is_error = false
+
+    if @child_answers['value'].to_hash.size == 15
+
+      if @answer.save
+        @child_answers['value'].each do |key, value|
+          if !(ChildAnswer.answer_setting(current_user, @answer, key, value))
+            is_error = true
+            break
+          end
+        end
+
+        if is_error
+          flash[:notice] = "振り返り実行に失敗しました"
+          @rules = current_user.rules ||= ""
+          render action: :new and return
+        end
+
+        flash[:notice] = "振り返りを実施しました"
+        redirect_to answers_index_path
+      end
+
+    else
+      is_error = true
+    end
+
+    if is_error
+      flash[:notice] = "振り返り実行に失敗しました"
+      @rules = current_user.rules ||= ""
+      render action: :new and return
+    end
+
+  end
+
+  def show
+  end
+
+  private
+
+  def answer_params
+    params.require(:answer).permit(value: {})
+  end
+end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -11,6 +11,12 @@ class AnswersController < ApplicationController
     @rules = current_user.rules
   end
 
+  def show
+    @answer = Answer.find_by(id: params[:id], user_id: current_user.id)
+    @child_answers = @answer.child_answers
+    @success_result = Answer.success_result(@answer)
+  end
+
   def create
 
     @rules = current_user.rules
@@ -28,16 +34,16 @@ class AnswersController < ApplicationController
           end
         end
 
-        Answer.score_create(@answer)
-
-        if is_error
+         if is_error
           flash[:notice] = "振り返り実行に失敗しました"
           @rules = current_user.rules ||= ""
           render action: :new and return
-        end
+         else
+          Answer.score_create(@answer)
+         end
 
         flash[:notice] = "振り返りを実施しました"
-        redirect_to answers_path
+        redirect_to answer_path(@answer)
       end
 
     else
@@ -50,9 +56,6 @@ class AnswersController < ApplicationController
       render action: :new and return
     end
 
-  end
-
-  def show
   end
 
   private

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -20,7 +20,7 @@ class RulesController < ApplicationController
     end
 
     if is_error
-      flash[:notice] = "ルール設定の更新に失敗しました"
+      flash.now[:notice] = "ルール設定の更新に失敗しました"
       @rules = current_user.rules ||= ""
       render action: :index and return
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       redirect_to new_user_session_path
       Rule.rule_setting(@user)
     else
-      flash[:alert] = "ユーザー登録に失敗しました。"
+      flash.now[:alert] = "ユーザー登録に失敗しました。"
       render action: :new and return
     end
   end

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -1,0 +1,2 @@
+module AnswersHelper
+end

--- a/app/javascript/answer.js
+++ b/app/javascript/answer.js
@@ -1,0 +1,15 @@
+$(document).ready(function() {
+  $('.tool-btn').on('click', function () {
+    var target = $(this).data('box-link');
+    console.log(target);
+    var box = $('#' + target);
+    console.log(box);
+    $(box).parent().addClass('is-inactive');
+    $(box).fadeIn();
+    $(this).parent().addClass('is-inactive');
+    $('.box .tool-btn').on('click', function () {
+      $(this).not($(this).parents('.box').fadeOut());
+      $(this).parents('.box').toggleClass('is-inactive');
+    });
+  });
+});

--- a/app/javascript/answer.js
+++ b/app/javascript/answer.js
@@ -1,9 +1,7 @@
 $(document).ready(function() {
   $('.tool-btn').on('click', function () {
-    var target = $(this).data('box-link');
-    console.log(target);
-    var box = $('#' + target);
-    console.log(box);
+    let target = $(this).data('box-link');
+    let box = $('#' + target);
     $(box).parent().addClass('is-inactive');
     $(box).fadeIn();
     $(this).parent().addClass('is-inactive');

--- a/app/javascript/packs/application.css
+++ b/app/javascript/packs/application.css
@@ -1,0 +1,12 @@
+.box-wrap .box {
+  display: none;
+  position: absolute;
+}
+
+.btn-wrap.is-inactive {
+  display: none;
+}
+
+.box-wrap.is-inactive .box{
+  position: relative;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,9 @@ import Rails from "@rails/ujs"
 import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
+require('jquery')
+require('answer.js')
+import "packs/application.css";
 
 Rails.start()
 Turbolinks.start()

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,9 +4,9 @@ class Answer < ApplicationRecord
 
   NUMBERSET = 1
 
-  MIN_NMBER = 1
-  SET_NMBER = 2
-  MAX_NMBER = 16
+  MIN_NUMBER = 1
+  SET_NUMBER = 2
+  MAX_NUMBER = 16
 
   def self.score_create(answer)
     child_answers = answer.child_answers

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -11,7 +11,7 @@ class Answer < ApplicationRecord
       success_result = content.count(true) * 1
       failure_result = content.count(false) * -1
       answer.score = success_result + failure_result
-      answer.save!
+      answer.save
     else
       is_error = true
     end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -17,4 +17,10 @@ class Answer < ApplicationRecord
     end
 
   end
+
+  def self.success_result(answer)
+    child_answers = answer.child_answers
+    content = child_answers.map { |child_answers| child_answers.content }
+    result = content.count(true) * 1
+  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -5,7 +5,7 @@ class Answer < ApplicationRecord
   def self.score_create(answer)
 
     child_answers = answer.child_answers
-    content = child_answers.map { |child_answers| child_answers.content }
+    content = child_answers.pluck(:content)
 
     if content.count == 15
       success_result = content.count(true) * 1
@@ -20,7 +20,7 @@ class Answer < ApplicationRecord
 
   def self.success_result(answer)
     child_answers = answer.child_answers
-    content = child_answers.map { |child_answers| child_answers.content }
+    content = child_answers.pluck(:content)
     result = content.count(true) * 1
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,4 @@
+class Answer < ApplicationRecord
+  belongs_to :user
+  has_many :child_answers, dependent: :destroy
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,25 +2,25 @@ class Answer < ApplicationRecord
   belongs_to :user
   has_many :child_answers, dependent: :destroy
 
-  def self.score_create(answer)
+  NUMBERSET = 1
 
+  def self.score_create(answer)
     child_answers = answer.child_answers
     content = child_answers.pluck(:content)
 
     if content.count == 15
-      success_result = content.count(true) * 1
-      failure_result = content.count(false) * -1
+      success_result = content.count(true) * NUMBERSET
+      failure_result = content.count(false) * -NUMBERSET
       answer.score = success_result + failure_result
       answer.save
     else
       is_error = true
     end
-
   end
 
   def self.success_result(answer)
     child_answers = answer.child_answers
     content = child_answers.pluck(:content)
-    result = content.count(true) * 1
+    result = content.count(true) * NUMBERSET
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,20 @@
 class Answer < ApplicationRecord
   belongs_to :user
   has_many :child_answers, dependent: :destroy
+
+  def self.score_create(answer)
+
+    child_answers = answer.child_answers
+    content = child_answers.map { |child_answers| child_answers.content }
+
+    if content.count == 15
+      success_result = content.count(true) * 1
+      failure_result = content.count(false) * -1
+      answer.score = success_result + failure_result
+      answer.save!
+    else
+      is_error = true
+    end
+
+  end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,6 +4,10 @@ class Answer < ApplicationRecord
 
   NUMBERSET = 1
 
+  MIN_NMBER = 1
+  SET_NMBER = 2
+  MAX_NMBER = 16
+
   def self.score_create(answer)
     child_answers = answer.child_answers
     content = child_answers.pluck(:content)

--- a/app/models/child_answer.rb
+++ b/app/models/child_answer.rb
@@ -1,0 +1,14 @@
+class ChildAnswer < ApplicationRecord
+  belongs_to :user
+  belongs_to :rule
+  belongs_to :answer
+
+  def self.answer_setting(user, answer, rule_id, value)
+    ChildAnswer.create(
+      user_id: user.id,
+      answer_id: answer.id,
+      rule_id: rule_id,
+      contnet: value
+    )
+  end
+end

--- a/app/models/child_answer.rb
+++ b/app/models/child_answer.rb
@@ -8,7 +8,7 @@ class ChildAnswer < ApplicationRecord
       user_id: user.id,
       answer_id: answer.id,
       rule_id: rule_id,
-      contnet: value
+      content: value
     )
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -1,5 +1,6 @@
 class Rule < ApplicationRecord
   belongs_to :user
+  has_many :child_answers, dependent: :destroy
   validates :rule_content, presence: true
 
   RULE_TITLES = [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   has_many :sns_credentials, dependent: :destroy
   has_many :rules, dependent: :destroy
+  has_many :answers, dependent: :destroy
+  has_many :child_answers, dependent: :destroy
 
   GUEST_USER_EMAIL = 'guest@example.com'.freeze
 

--- a/app/views/answers/board.html.erb
+++ b/app/views/answers/board.html.erb
@@ -1,0 +1,3 @@
+<h1>掲示板</h1>
+
+<%= render partial: '/shared/answer_form', locals: { answers: @answers } %>

--- a/app/views/answers/index.html.erb
+++ b/app/views/answers/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Answers#index</h1>
+<p>Find me in app/views/answers/index.html.erb</p>

--- a/app/views/answers/index.html.erb
+++ b/app/views/answers/index.html.erb
@@ -1,2 +1,5 @@
-<h1>Answers#index</h1>
-<p>Find me in app/views/answers/index.html.erb</p>
+<h1>回答一覧</h1>
+
+<%= render partial: '/shared/answer_link' %>
+
+<%= render partial: '/shared/answer_form', locals: { answers: @answers } %>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -9,15 +9,15 @@
   <div class="diagnose-wrap">
     <div class="inner-block">
       <div class="btn-wrap">
-        <%= button_tag "振り返り実施", class: "tool-btn start-btn", type: "button",  data: {box_link: "q#{Answer::MIN_NMBER}"} %>
+        <%= button_tag "振り返り実施", class: "tool-btn start-btn", type: "button",  data: {box_link: "q#{Answer::MIN_NUMBER}"} %>
       </div>
       <div class="box-wrap">
         <%= form_tag(answers_path, method: :post) do %>
           <% @rules.each_with_index do |rule, i| %>
             <% if rule.rule_title == "" && rule.rule_type_id %>
-              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+              <div id= "q<%= i+Answer::MIN_NUMBER %>" class="box">
                 <h3>
-                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_content}"%><br>
+                  <%= "No#{i+Answer::MIN_NUMBER}: #{rule.rule_content}"%><br>
                 </h3>
                 <div class="select-wrap">
                   <label>
@@ -28,13 +28,13 @@
                   </label><br>
                 </div>
                 <div class="btn-wrap">
-                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NUMBER}"} %>
                 </div>
               </div>
-            <% elsif rule.rule_type_id == true %>
-              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+            <% elsif rule.rule_type_id %>
+              <div id= "q<%= i+Answer::MIN_NUMBER %>" class="box">
                 <h3>
-                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_content + rule.rule_title}"%><br>
+                  <%= "No#{i+Answer::MIN_NUMBER}: #{rule.rule_content + rule.rule_title}"%><br>
                 </h3>
                 <div class="select-wrap">
                   <label>
@@ -45,13 +45,13 @@
                   </label><br>
                 </div>
                 <div class="btn-wrap">
-                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NUMBER}"} %>
                 </div>
               </div>
-              <% elsif i == @rules.size-Answer::MIN_NMBER %>
-                <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+              <% elsif i == @rules.size-Answer::MIN_NUMBER %>
+                <div id= "q<%= i+Answer::MIN_NUMBER %>" class="box">
                   <h3>
-                    <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_title}"%><br>
+                    <%= "No#{i+Answer::MIN_NUMBER}: #{rule.rule_title}"%><br>
                   </h3>
 
                   <div class="select-wrap">
@@ -64,13 +64,13 @@
                   </div>
 
                   <div class="btn-wrap">
-                    <%= button_tag "終了する", class: "tool-btn next result is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                    <%= button_tag "終了する", class: "tool-btn next result is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NUMBER}"} %>
                   </div>
                 </div>
             <% else %>
-              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+              <div id= "q<%= i+Answer::MIN_NUMBER %>" class="box">
                 <h3>
-                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_title}"%><br>
+                  <%= "No#{i+Answer::MIN_NUMBER}: #{rule.rule_title}"%><br>
                 </h3>
                 <div class="select-wrap">
                   <label>
@@ -81,14 +81,14 @@
                   </label><br>
                 </div>
                 <div class="btn-wrap">
-                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NUMBER}"} %>
                 </div>
               </div>
             <% end %>
           <% end %>
-          <div id= "q<%= Answer::MAX_NMBER %>" class="box">
+          <div id= "q<%= Answer::MAX_NUMBER %>" class="box">
             <div class="btn-wrap">
-              <%= submit_tag '回答を保存する', class: "tool-btn next is-active", data: {box_link: "q#{Answer::MAX_NMBER}"}  %>
+              <%= submit_tag '回答を保存する', class: "tool-btn next is-active", data: {box_link: "q#{Answer::MAX_NUMBER}"}  %>
             </div>
           </div>
         <% end %>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -7,10 +7,10 @@
         <%= "No#{i+1}: #{rule.rule_content}"%><br>
       </h3>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
       </label>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
       </label><br>
 
 
@@ -19,10 +19,10 @@
         <%= "No#{i+1}: #{rule.rule_content + rule.rule_title}"%><br>
       </h3>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
       </label>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
       </label><br>
 
 
@@ -31,10 +31,10 @@
           <%= "No#{i+1}: #{rule.rule_title}"%><br>
       </h3>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
       </label>
       <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
       </label><br>
 
 

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(answers_create_path, method: :post) do %>
+<%= form_tag(answers_path, method: :post) do %>
 
   <% @rules.each_with_index do |rule, i| %>
 

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -2,7 +2,7 @@
 
   <% @rules.each_with_index do |rule, i| %>
 
-    <% if rule.rule_title == "" && rule.rule_type_id == true %>
+    <% if rule.rule_title == "" && rule.rule_type_id %>
       <h3>
         <%= "No#{i+1}: #{rule.rule_content}"%><br>
       </h3>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,47 +1,79 @@
-<%= form_tag(answers_path, method: :post) do %>
-
-  <% @rules.each_with_index do |rule, i| %>
-
-    <% if rule.rule_title == "" && rule.rule_type_id %>
-      <h3>
-        <%= "No#{i+1}: #{rule.rule_content}"%><br>
-      </h3>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
-      </label>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
-      </label><br>
-
-
-    <% elsif rule.rule_type_id == true %>
-      <h3>
-        <%= "No#{i+1}: #{rule.rule_content + rule.rule_title}"%><br>
-      </h3>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
-      </label>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
-      </label><br>
-
-
-    <% else %>
-      <h3>
-          <%= "No#{i+1}: #{rule.rule_title}"%><br>
-      </h3>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
-      </label>
-      <label>
-          <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
-      </label><br>
-
-
-    <% end %>
-
-  <% end %>
-
-  <%= submit_tag '診断する'  %>
-
-<% end %>
+<div class="wrap">
+  <div class="title-wrap">
+    <div class="inner-block">
+      <h1 class="title">
+        振り返り
+      </h1>
+    </div>
+  </div>
+  <div class="diagnose-wrap">
+    <div class="inner-block">
+      <div class="btn-wrap">
+        <%= button_tag "振り返り実施", class: "tool-btn start-btn", type: "button",  data: {box_link: "q#{Answer::MIN_NMBER}"} %>
+      </div>
+      <div class="box-wrap">
+        <%= form_tag(answers_path, method: :post) do %>
+          <% @rules.each_with_index do |rule, i| %>
+            <% if rule.rule_title == "" && rule.rule_type_id %>
+              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+                <h3>
+                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_content}"%><br>
+                </h3>
+                <div class="select-wrap">
+                  <label>
+                      <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
+                  </label>
+                  <label>
+                      <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
+                  </label><br>
+                </div>
+                <div class="btn-wrap">
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                </div>
+              </div>
+            <% elsif rule.rule_type_id == true %>
+              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+                <h3>
+                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_content + rule.rule_title}"%><br>
+                </h3>
+                <div class="select-wrap">
+                  <label>
+                    <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
+                  </label>
+                  <label>
+                    <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
+                  </label><br>
+                </div>
+                <div class="btn-wrap">
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                </div>
+              </div>
+            <% else %>
+              <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+                <h3>
+                  <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_title}"%><br>
+                </h3>
+                <div class="select-wrap">
+                  <label>
+                      <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
+                  </label>
+                  <label>
+                      <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
+                  </label><br>
+                </div>
+                <div class="btn-wrap">
+                  <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+          <div id= "q<%= Answer::MAX_NMBER %>" class="box">
+            <div class="btn-wrap">
+              <%= submit_tag '回答を保存する', class: "tool-btn next is-active", data: {box_link: "q#{Answer::MAX_NMBER}"}  %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,0 +1,47 @@
+<%= form_tag(answers_create_path, method: :post) do %>
+
+  <% @rules.each_with_index do |rule, i| %>
+
+    <% if rule.rule_title == "" && rule.rule_type_id == true %>
+      <h3>
+        <%= "No#{i+1}: #{rule.rule_content}"%><br>
+      </h3>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+      </label>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+      </label><br>
+
+
+    <% elsif rule.rule_type_id == true %>
+      <h3>
+        <%= "No#{i+1}: #{rule.rule_content + rule.rule_title}"%><br>
+      </h3>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+      </label>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+      </label><br>
+
+
+    <% else %>
+      <h3>
+          <%= "No#{i+1}: #{rule.rule_title}"%><br>
+      </h3>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", true %> 達成
+      </label>
+      <label>
+          <%= radio_button_tag "answer[value][#{rule.id}]", false %> 未達
+      </label><br>
+
+
+    <% end %>
+
+  <% end %>
+
+  <%= submit_tag '診断する'  %>
+
+<% end %>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -48,6 +48,25 @@
                   <%= button_tag "次の質問へ", class: "tool-btn next is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
                 </div>
               </div>
+              <% elsif i == @rules.size-Answer::MIN_NMBER %>
+                <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
+                  <h3>
+                    <%= "No#{i+Answer::MIN_NMBER}: #{rule.rule_title}"%><br>
+                  </h3>
+
+                  <div class="select-wrap">
+                    <label>
+                        <%= radio_button_tag "answer[value][#{rule.id}]", true, :required %> 達成
+                    </label>
+                    <label>
+                        <%= radio_button_tag "answer[value][#{rule.id}]", false, :required %> 未達
+                    </label><br>
+                  </div>
+
+                  <div class="btn-wrap">
+                    <%= button_tag "終了する", class: "tool-btn next result is-active", type: "button",  data: {box_link: "q#{i+Answer::SET_NMBER}"} %>
+                  </div>
+                </div>
             <% else %>
               <div id= "q<%= i+Answer::MIN_NMBER %>" class="box">
                 <h3>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Answers#show</h1>
+<p>Find me in app/views/answers/show.html.erb</p>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,2 +1,18 @@
-<h1>Answers#show</h1>
-<p>Find me in app/views/answers/show.html.erb</p>
+<%= "日付: #{@answer.created_at.strftime('%Y/%m/%d') }" %><br>
+<%= "スコア: #{@answer.score}点" %> <%= "正解率: #{@success_result}/15" %><br>
+<br>
+<%= "回答一覧" %> <br>
+<br>
+
+<% @child_answers.each_with_index do |child_answers, i| %>
+  <% if child_answers.rule.rule_title == "" && child_answers.rule.rule_type_id == true %>
+    <%= "No#{i+1}: " %><%= child_answers.rule.rule_content %>  <%= child_answers.content ? '達成' : '未達成' %><br>
+    <br>
+  <% elsif child_answers.rule.rule_type_id == true %>
+    <%= "No#{i+1}: " %><%= child_answers.rule.rule_content + child_answers.rule.rule_title%>  <%= child_answers.content ? '達成' : '未達成' %><br>
+    <br>
+  <% else %>
+    <%= "No#{i+1}: " %><%= child_answers.rule.rule_title %>  <%= child_answers.content ? '達成' : '未達成' %><br>
+    <br>
+  <% end %>
+<% end %>

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,18 +1,20 @@
+<h1>詳細ページ</h1>
+
+<%= render partial: '/shared/answer_link' %>
+
 <%= "日付: #{@answer.created_at.strftime('%Y/%m/%d') }" %><br>
-<%= "スコア: #{@answer.score}点" %> <%= "正解率: #{@success_result}/15" %><br>
-<br>
-<%= "回答一覧" %> <br>
+<%= "作成者: #{@answer.user.name}" %><br>
+<%= "スコア: #{@answer.score}点" %><br>
+<%= "達成率: #{Answer.success_result(@answer)}/15" %><br>
 <br>
 
+<%= "回答一覧" %> <br>
 <% @child_answers.each_with_index do |child_answers, i| %>
   <% if child_answers.rule.rule_title == "" && child_answers.rule.rule_type_id == true %>
     <%= "No#{i+1}: " %><%= child_answers.rule.rule_content %>  <%= child_answers.content ? '達成' : '未達成' %><br>
-    <br>
   <% elsif child_answers.rule.rule_type_id == true %>
     <%= "No#{i+1}: " %><%= child_answers.rule.rule_content + child_answers.rule.rule_title%>  <%= child_answers.content ? '達成' : '未達成' %><br>
-    <br>
   <% else %>
     <%= "No#{i+1}: " %><%= child_answers.rule.rule_title %>  <%= child_answers.content ? '達成' : '未達成' %><br>
-    <br>
   <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_pack_tag 'application' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
         <% if user_signed_in? %>
           <%= link_to 'トップページ', root_path %>
           <%= link_to '振り返り設定', rules_path %>
+          <%= link_to '振り返り実施', answers_new_path %>
           <%= link_to 'プロフィール変更', edit_user_registration_path %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
         <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
         <% if user_signed_in? %>
           <%= link_to 'トップページ', root_path %>
           <%= link_to '振り返り設定', rules_path %>
-          <%= link_to '振り返り実施', answers_new_path %>
+          <%= link_to '振り返り実施', new_answer_path %>
           <%= link_to 'プロフィール変更', edit_user_registration_path %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
         <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
       <nav>
         <% if user_signed_in? %>
           <%= link_to 'トップページ', root_path %>
-          <%= link_to '振り返り設定', rules_path %>
-          <%= link_to '振り返り実施', new_answer_path %>
+          <%= link_to '振り返り', answer_pages_path %>
+          <%= link_to '掲示板', board_answers_path %>
           <%= link_to 'プロフィール変更', edit_user_registration_path %>
           <%= link_to 'ログアウト', destroy_user_session_path, method: :delete %>
         <% else %>

--- a/app/views/pages/answer.html.erb
+++ b/app/views/pages/answer.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: '/shared/answer_link' %>

--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -1,3 +1,7 @@
+<h1>振り返り設定</h1>
+
+<%= render partial: '/shared/answer_link' %>
+
 <%= form_tag (rules_update_path) do %>
 
   <% @rules.each_with_index do |rule, i| %>

--- a/app/views/shared/_answer_form.html.erb
+++ b/app/views/shared/_answer_form.html.erb
@@ -1,0 +1,10 @@
+<% answers.each do |answer| %>
+  <%= link_to answer_path(answer) do %>
+    <%= "日付: #{answer.created_at.strftime('%Y/%m/%d') }" %><br>
+    <%= "作成者: #{answer.user.name}" %><br>
+    <%= "スコア: #{answer.score}点" %><br>
+    <%= "達成率: #{Answer.success_result(answer)}/15" %><br>
+    <br>
+    <br>
+  <% end %>
+<% end %>

--- a/app/views/shared/_answer_link.html.erb
+++ b/app/views/shared/_answer_link.html.erb
@@ -1,7 +1,7 @@
 <br>
 <%= link_to '振り返り設定', rules_path %><br>
 <br>
-<%= link_to '振り返り実行', new_answer_path %><br>
+<%= link_to '振り返り実行', new_answer_path, data: {turbolinks: false} %><br>
 <br>
 <%= link_to '振り返り結果一覧', answers_path %><br>
 <br>

--- a/app/views/shared/_answer_link.html.erb
+++ b/app/views/shared/_answer_link.html.erb
@@ -1,0 +1,7 @@
+<br>
+<%= link_to '振り返り設定', rules_path %><br>
+<br>
+<%= link_to '振り返り実行', new_answer_path %><br>
+<br>
+<%= link_to '振り返り結果一覧', answers_path %><br>
+<br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
 
-  resources :answers, only: %i[index new show create]
+  resources :answers, only: %i[index new show create] do
+    collection do
+      get 'board'
+    end
+  end
 
   get '/rules', to: 'rules#index'
   post 'rules/update', to: 'rules#update'
@@ -18,4 +22,11 @@ Rails.application.routes.draw do
 
   root 'pages#index'
   get 'pages/show'
+
+
+  resources :pages, only: %i[index  show ] do
+    collection do
+      get 'answer'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,9 @@
 Rails.application.routes.draw do
 
-  resources :answers
+  resources :answers, only: %i[index new show create]
 
   get '/rules', to: 'rules#index'
   post 'rules/update', to: 'rules#update'
-
-
 
   devise_for :users, controllers: {
     registrations: 'users/registrations',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,6 @@
 Rails.application.routes.draw do
 
-
-  get 'answers/index'
-  get 'answers/new'
-  get 'answers/show'
-  post 'answers/create', to: 'answers#create'
-
-  resources :child_answers
+  resources :answers
 
   get '/rules', to: 'rules#index'
   post 'rules/update', to: 'rules#update'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,13 @@
 Rails.application.routes.draw do
 
 
+  get 'answers/index'
+  get 'answers/new'
+  get 'answers/show'
+  post 'answers/create', to: 'answers#create'
+
+  resources :child_answers
+
   get '/rules', to: 'rules#index'
   post 'rules/update', to: 'rules#update'
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/db/migrate/20240109204533_create_answers.rb
+++ b/db/migrate/20240109204533_create_answers.rb
@@ -1,0 +1,10 @@
+class CreateAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :answers do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :score
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240109214850_create_child_answers.rb
+++ b/db/migrate/20240109214850_create_child_answers.rb
@@ -1,0 +1,12 @@
+class CreateChildAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :child_answers do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :rule, null: false, foreign_key: true
+      t.references :answer, null: false, foreign_key: true
+      t.boolean :contnet, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240109214850_create_child_answers.rb
+++ b/db/migrate/20240109214850_create_child_answers.rb
@@ -4,7 +4,7 @@ class CreateChildAnswers < ActiveRecord::Migration[6.1]
       t.references :user, null: false, foreign_key: true
       t.references :rule, null: false, foreign_key: true
       t.references :answer, null: false, foreign_key: true
-      t.boolean :contnet, null: false, default: false
+      t.boolean :content, null: false, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_06_022321) do
+ActiveRecord::Schema.define(version: 2024_01_09_214850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "score"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_answers_on_user_id"
+  end
+
+  create_table "child_answers", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "rule_id", null: false
+    t.bigint "answer_id", null: false
+    t.boolean "contnet", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["answer_id"], name: "index_child_answers_on_answer_id"
+    t.index ["rule_id"], name: "index_child_answers_on_rule_id"
+    t.index ["user_id"], name: "index_child_answers_on_user_id"
+  end
 
   create_table "rules", force: :cascade do |t|
     t.string "rule_title", null: false
@@ -64,6 +84,10 @@ ActiveRecord::Schema.define(version: 2024_01_06_022321) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "answers", "users"
+  add_foreign_key "child_answers", "answers"
+  add_foreign_key "child_answers", "rules"
+  add_foreign_key "child_answers", "users"
   add_foreign_key "rules", "users"
   add_foreign_key "sns_credentials", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2024_01_09_214850) do
     t.bigint "user_id", null: false
     t.bigint "rule_id", null: false
     t.bigint "answer_id", null: false
-    t.boolean "contnet", default: false, null: false
+    t.boolean "content", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["answer_id"], name: "index_child_answers_on_answer_id"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.4",
+    "jquery": "^3.7.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/test/controllers/answers_controller_test.rb
+++ b/test/controllers/answers_controller_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class AnswersControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get answers_index_url
+    get answers_url
     assert_response :success
   end
 
   test "should get new" do
-    get answers_new_url
+    get new_answer_url
     assert_response :success
   end
 

--- a/test/controllers/answers_controller_test.rb
+++ b/test/controllers/answers_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AnswersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get answers_index_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get answers_new_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get answers_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  score: 1
+
+two:
+  user: two
+  score: 1

--- a/test/fixtures/child_answers.yml
+++ b/test/fixtures/child_answers.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  rule: one
+  answer: one
+  content: false
+
+two:
+  user: two
+  rule: two
+  answer: two
+  content: false

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/child_answer_test.rb
+++ b/test/models/child_answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChildAnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,6 +4085,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
+  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## 変更の目的
ルール機能で実装したルールを遵守できているか質問に回答していく「振り返り機能」を実装した。

## 変更内容


### テーブル追加
- Answersテーブル：誰が「振り返り」をしたか保存
![image](https://github.com/Mekun-k/MonkMode/assets/83563470/0e4fb0ca-c69c-4bd1-a363-370e64f2d3e3)


- ChildAnswersテーブル：「振り返り」結果の保存
![image](https://github.com/Mekun-k/MonkMode/assets/83563470/1b7b7d42-469d-48c8-bdc8-6bf289bf7336)

- トップページ上部に「振り返り実施」リンクを追記
- 「振り返り実施」リンクから「振り返り実施」ページにアクセス可
- 「振り返り設定ページ」で設定したルールが、「振り返り実施ページ」で質問として表示されている
- 各問にラジオボタン「達成」「未達」を設置、ユーザーにクリックしてもらう
- 全てのラジオボタンにチェックをいれずに診断した場合、保存がされないようにした
- ログイン前に「振り返り実施ページ」にアクセスできないようにした

## 確認手順

1.  ログインページにアクセス(http://localhost:3000/users/sign_in)
2. ページ下部にある「ゲストログイン」をクリックしてゲストログインを実施して、トップページに遷移
3. トップページにて「振り返り実施」をクリックして「振り返り実施ページ」にアクセスする(http://localhost:3000/answers/new)
4. 各問のラジオボタンをクリックしてページ下部にある「診断」をクリックする

### ログイン前に「振り返り実施ページ」にアクセスできないようにした
 1. ログアウトしている状態を確認
 3. URLに「振り返り実施ページ」のURLを打ち込む(http://localhost:3000/answers/new)
 4. アクセスできずトップページに遷移、フラッシュメッセージにて「ログインもしくはアカウント登録してください。」と表示されることを確認

## 残りの実装
- 振り返り実施ページのラジオボタンにrequiredオプションをつけチェック必須にする
- 振り返り詳細ページ
- 振り返り一覧機能
- 掲示板機能
- スコア機能
