### PR TITLE
Fix: パスワード再設定時に登録の無いメールアドレスが分かってしまう状態だったのでオーバーライドしたcreateアクションを修正

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,8 +1,15 @@
 class Users::PasswordsController < Devise::PasswordsController
   before_action :ensure_normal_user, only: :create
 
-  def create # rubocop:disable Lint/UselessMethodDefinition
-    super
+  def create
+    self.resource = resource_class.send_reset_password_instructions(resource_params)
+    yield resource if block_given?
+
+    if successfully_sent?(resource)
+      respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+    else
+      redirect_to new_user_session_path, notice: "パスワードの再設定について数分以内にメールでご連絡いたします。"
+    end
   end
 
   def ensure_normal_user


### PR DESCRIPTION
Close #28 